### PR TITLE
feat(command): add ast-grep.restartLanguageServer command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
         "command": "ast-grep.search",
         "title": "Search pattern in current document",
         "category": "ast-grep"
+      },
+      {
+        "command": "ast-grep.restartLanguageServer",
+        "title": "restart Language Server",
+        "category": "ast-grep"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,10 +209,21 @@ function activateLsp(context: ExtensionContext) {
   )
 
   context.subscriptions.push(
-    workspace.onDidChangeConfiguration(changeEvent => {
+    commands.registerCommand('ast-grep.restartLanguageServer', async () => {
+      console.log(
+        'Restart the ast-grep language server by ast-grep.restart command'
+      )
+      await restart()
+    })
+  )
+
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(async changeEvent => {
       if (changeEvent.affectsConfiguration('astGrep')) {
-        deactivate()
-        client.start()
+        console.log(
+          'Restart the ast-grep language server due to modification of vscode settings'
+        )
+        await restart()
       }
     })
   )

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -344,9 +344,11 @@ export function activate(context: ExtensionContext) {
   activateWebview(context)
 }
 
-async function restart() {
+async function restart(): Promise<void> {
   await deactivate()
-  return await client.start()
+  if (client) {
+    await client.start()
+  }
 }
 
 export function deactivate(): Promise<void> | undefined {

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
-import * as assert from 'assert'
 
-import { getDocUri } from './utils'
+import { getDocUri, testDiagnostics, toRange } from './utils'
 
 suite('Should get diagnostics', () => {
   const docUri = getDocUri('test.ts')
@@ -28,28 +27,3 @@ suite('Should get diagnostics', () => {
     ])
   })
 })
-
-function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
-  const start = new vscode.Position(sLine, sChar)
-  const end = new vscode.Position(eLine, eChar)
-  return new vscode.Range(start, end)
-}
-
-async function testDiagnostics(
-  docUri: vscode.Uri,
-  expectedDiagnostics: vscode.Diagnostic[]
-) {
-  const actualDiagnostics = vscode.languages.getDiagnostics(docUri)
-  actualDiagnostics.sort((a, b) =>
-    a.message === b.message ? 0 : a.message > b.message ? 1 : -1
-  )
-
-  assert.equal(actualDiagnostics.length, expectedDiagnostics.length)
-
-  expectedDiagnostics.forEach((expectedDiagnostic, i) => {
-    const actualDiagnostic = actualDiagnostics[i]
-    assert.equal(actualDiagnostic.message, expectedDiagnostic.message)
-    assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range)
-    assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity)
-  })
-}

--- a/src/test/fileModifications.test.ts
+++ b/src/test/fileModifications.test.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import * as yaml from 'js-yaml'
 
-import { getDocUri, sleep, assertDiagnosticsEqual } from './utils'
+import { getDocUri, sleep, assertDiagnosticsEqual, toRange } from './utils'
 
 const docUri = getDocUri('test.ts')
 const diagnostics = getExpectedDiagnosticss()
@@ -92,12 +92,6 @@ suite('Should update when files change', () => {
     )
   })
 })
-
-function toRange(sLine: number, sChar: number, eLine: number, eChar: number) {
-  const start = new vscode.Position(sLine, sChar)
-  const end = new vscode.Position(eLine, eChar)
-  return new vscode.Range(start, end)
-}
 
 function getExpectedDiagnosticss() {
   const full = [

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -11,13 +11,13 @@ suite('ast-grep.restartLanguageServer should work', () => {
     // remove configFile should receive no diagnostics
     await vscode.workspace.fs.rename(sgConfigYml, tempSgConfigYml)
     await vscode.commands.executeCommand('ast-grep.restartLanguageServer')
-    await sleep(2000)
+    await sleep(3000)
     await testDiagnostics(docUri, [])
 
     // should receive diagnostics after add configFile
     await vscode.workspace.fs.rename(tempSgConfigYml, sgConfigYml)
     await vscode.commands.executeCommand('ast-grep.restartLanguageServer')
-    await sleep(2000)
+    await sleep(3000)
     await testDiagnostics(docUri, [
       {
         message: 'No console.log',

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode'
+
+import { getDocUri, sleep, testDiagnostics, toRange } from './utils'
+
+suite('ast-grep.restartLanguageServer should work', () => {
+  const docUri = getDocUri('test.ts')
+  const sgConfigYml = getDocUri('sgconfig.yml')
+  const tempSgConfigYml = getDocUri('_sgconfig.yml')
+
+  test('Delete or create the sgconfig.yml', async () => {
+    // remove configFile should receive no diagnostics
+    await vscode.workspace.fs.rename(sgConfigYml, tempSgConfigYml)
+    await vscode.commands.executeCommand('ast-grep.restartLanguageServer')
+    await sleep(2000)
+    await testDiagnostics(docUri, [])
+
+    // should receive diagnostics after add configFile
+    await vscode.workspace.fs.rename(tempSgConfigYml, sgConfigYml)
+    await vscode.commands.executeCommand('ast-grep.restartLanguageServer')
+    await sleep(2000)
+    await testDiagnostics(docUri, [
+      {
+        message: 'No console.log',
+        range: toRange(2, 4, 2, 32),
+        severity: vscode.DiagnosticSeverity.Warning,
+        source: 'ex'
+      },
+      {
+        message: 'Test rule for vscode extension',
+        range: toRange(0, 0, 4, 1),
+        severity: vscode.DiagnosticSeverity.Error,
+        source: 'ex'
+      },
+      {
+        message: 'Test rule for vscode extension',
+        range: toRange(6, 0, 10, 1),
+        severity: vscode.DiagnosticSeverity.Error,
+        source: 'ex'
+      }
+    ])
+  })
+})

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -79,3 +79,33 @@ export async function setTestContent(content: string): Promise<boolean> {
   )
   return editor.edit(eb => eb.replace(all, content))
 }
+
+export async function testDiagnostics(
+  docUri: vscode.Uri,
+  expectedDiagnostics: vscode.Diagnostic[]
+) {
+  const actualDiagnostics = vscode.languages.getDiagnostics(docUri)
+  actualDiagnostics.sort((a, b) =>
+    a.message === b.message ? 0 : a.message > b.message ? 1 : -1
+  )
+
+  assert.equal(actualDiagnostics.length, expectedDiagnostics.length)
+
+  expectedDiagnostics.forEach((expectedDiagnostic, i) => {
+    const actualDiagnostic = actualDiagnostics[i]
+    assert.equal(actualDiagnostic.message, expectedDiagnostic.message)
+    assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range)
+    assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity)
+  })
+}
+
+export function toRange(
+  sLine: number,
+  sChar: number,
+  eLine: number,
+  eChar: number
+) {
+  const start = new vscode.Position(sLine, sChar)
+  const end = new vscode.Position(eLine, eChar)
+  return new vscode.Range(start, end)
+}


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 871548d8a79d59371a796d6e2ad930dd1a1ae436.  | 
|--------|--------|

### Summary:
This PR adds a new command to restart the language server, modifies the `workspace.onDidChangeConfiguration` event to restart the server on configuration changes, refactors test utilities, and adds a new test for the restart functionality.

**Key points**:
- Added `ast-grep.restartLanguageServer` command in `src/extension.ts`.
- Modified `workspace.onDidChangeConfiguration` event in `src/extension.ts` to restart the language server on `astGrep` configuration changes.
- Moved `toRange` and `testDiagnostics` functions from `diagnostics.test.ts` to `utils.ts`.
- Added new test file `restart.test.ts` to test the restart functionality.
- Updated `utils.ts` with moved functions and a new `waitForDiagnosticChange` function.
----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
