### PR TITLE
fix: simplify vscode launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,11 +6,12 @@
       "request": "launch",
       "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceRoot}"
-        // "--disable-extensions"
-      ],
-      "preLaunchTask": "tasks: dev"
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "outFiles": ["${workspaceRoot}/client/out/**/*.js"],
+      "preLaunchTask": {
+        "type": "npm",
+        "script": "watch"
+      }
     },
     {
       "name": "Language Client E2E Test",
@@ -21,7 +22,8 @@
         "--extensionDevelopmentPath=${workspaceRoot}",
         "--extensionTestsPath=${workspaceRoot}/out/test/index",
         "${workspaceRoot}/client/testFixture"
-      ]
+      ],
+      "outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,18 +8,8 @@
       "presentation": {
         "panel": "dedicated",
         "reveal": "never"
-      }
-    },
-    {
-      "type": "npm",
-      "script": "watch:webview",
-      "problemMatcher": "$ts-webpack-watch",
-      "isBackground": true,
-      "presentation": {
-        "reveal": "never",
-        "group": "watchers"
       },
-      "group": "build"
+      "problemMatcher": []
     },
     {
       "type": "npm",
@@ -33,20 +23,6 @@
         "panel": "dedicated",
         "reveal": "never"
       },
-      "problemMatcher": [
-        {
-          "base": "$ts-webpack-watch",
-          "background": {
-            "activeOnStart": true,
-            "beginsPattern": "Build start",
-            "endsPattern": "Build success"
-          }
-        }
-      ]
-    },
-    {
-      "label": "tasks: dev",
-      "dependsOn": ["npm: watch", "npm: watch:webview"],
       "problemMatcher": []
     }
   ]

--- a/src/view.ts
+++ b/src/view.ts
@@ -90,20 +90,9 @@ class SearchSidebarProvider implements vscode.WebviewViewProvider {
   }
 
   private getHtmlForWebview(webview: vscode.Webview) {
-    const localPort = 3000
-    const localServerUrl = `http://localhost:${localPort}/index.js`
-
-    const scriptUri =
-      process.env.NODE_ENV !== 'production'
-        ? localServerUrl
-        : webview.asWebviewUri(
-            vscode.Uri.joinPath(
-              this._extensionUri,
-              'out',
-              'webview',
-              'index.js'
-            )
-          )
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this._extensionUri, 'out', 'webview', 'index.js')
+    )
 
     const stylesResetUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, 'media', 'reset.css')

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,16 +3,12 @@ import { defineConfig } from 'tsup'
 const isDev = process.env.NODE_ENV !== 'production'
 
 export default defineConfig({
-  entry: [
-    'src/extension.ts',
-    'src/view.ts',
-    ...(isDev ? [] : ['src/webview/index.tsx'])
-  ],
+  entry: ['src/extension.ts', 'src/view.ts', 'src/webview/index.tsx'],
   outDir: 'out',
   sourcemap: isDev ? 'inline' : false,
   clean: !isDev,
   bundle: true,
-  dts: true,
+  dts: false,
   external: ['vscode'],
   env: {
     NODE_ENV: process.env.NODE_ENV ?? 'production'


### PR DESCRIPTION
this pull request simplifies vscode launch problem.
Now it does not rely on external extensions. Nor it requires webpack. 

webpack will be removed in following pull requests.

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 025f8a31653a75424ff85b8f51c04e65f2f25dcb.  | 
|--------|--------|

### Summary:
This PR simplifies the vscode launch task by removing the dependency on external extensions and webpack, and directly pointing the `scriptUri` to the `index.js` file in the `webview` directory.

**Key points**:
- Removed local server setup in `getHtmlForWebview` function in `SearchSidebarProvider` class.
- `scriptUri` now directly points to `index.js` in `webview` directory.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
