### PR TITLE
feat: move view panel from references to sg panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,14 @@
       "ast-grep-sidebar-view": [
         {
           "type": "webview",
-          "id": "ast-grep.search.panel",
-          "name": "Structural Search"
+          "id": "ast-grep.search.input",
+          "name": "Pattern Input"
+        },
+        {
+          "name": "Structural Search Result",
+          "id": "ast-grep.search.result",
+          "icon": "media/favicon.svg",
+          "contextualTitle": "Package Explorer"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,20 +137,7 @@ class NodeDependenciesProvider
   }
 
   updateResult(res: ScanResult[]) {
-    let treeItemList: AstGrepScanTreeItem[] = []
     let grouped = groupBy(res, 'uri')
-    for (let uri of Object.keys(grouped)) {
-      let scanResultList = grouped[uri]
-      for (let element of scanResultList) {
-        treeItemList.push(
-          new AstGrepScanTreeItem({
-            source: element.content,
-            range: element.position,
-            uri: element.uri
-          })
-        )
-      }
-    }
     this.scanResultDict = grouped
     this.emitter.fire(undefined)
   }

--- a/src/view.ts
+++ b/src/view.ts
@@ -41,7 +41,7 @@ async function getPatternRes(pattern: string) {
 }
 
 class SearchSidebarProvider implements vscode.WebviewViewProvider {
-  public static readonly viewType = 'ast-grep.search.panel'
+  public static readonly viewType = 'ast-grep.search.input'
 
   // @ts-expect-error
   private _view?: vscode.WebviewView

--- a/src/webview/SearchSidebar/index.tsx
+++ b/src/webview/SearchSidebar/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import type { SgSearch } from '../../types'
-import SearchResultsList from './SearchResultList'
+// import SearchResultsList from './SearchResultList'
 import SearchWidgetContainer from './SearchWidgetContainer'
 import { useSgSearch } from './postMessage'
 import { useState } from 'react'
@@ -30,7 +30,8 @@ export const SearchSidebar = () => {
     'ast-grep-search-panel-input-value',
     ''
   )
-  const { searchResult, refreshSearchResult } = useSearchResult(inputValue)
+  // const { searchResult, refreshSearchResult } = useSearchResult(inputValue)
+  const { refreshSearchResult } = useSearchResult(inputValue)
 
   return (
     <div>
@@ -39,7 +40,9 @@ export const SearchSidebar = () => {
         refreshResult={refreshSearchResult}
         setInputValue={setInputValue}
       />
-      <SearchResultsList matches={searchResult} />
+      {/* // TODO: add customized tree result
+        <SearchResultsList matches={searchResult} />
+      */}
     </div>
   )
 }


### PR DESCRIPTION
Previous, ast-grep.search's output is inside a reference panel. This commit changed it to standalone panel

after:

<img width="1024" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/2165c47f-4c18-4005-8475-ee67f9ac46d9">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 22efb4685e1641615ca2e99fdf8a53edb0284bef.  | 
|--------|--------|

### Summary:
This PR moves the output of `ast-grep.search` from a reference panel to a standalone panel by modifying the `NodeDependenciesProvider` class and the `activateLsp` function in `src/extension.ts`, and updating the `viewType` in `src/view.ts`.

**Key points**:
- Modified `NodeDependenciesProvider` class in `src/extension.ts` to include an `EventEmitter` and a new `updateResult` method.
- Updated `activateLsp` function in `src/extension.ts` to create a new `TreeView` with `NodeDependenciesProvider` as the tree data provider.
- The `ast-grep.search` command now updates the results using the `updateResult` method of `NodeDependenciesProvider`.
- Updated `viewType` in `src/view.ts` from `ast-grep.search.panel` to `ast-grep.search.input`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
