### PR TITLE
feat: add lines context to search result

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import {
   commands,
   Range,
   TreeItem,
+  TreeItemLabel,
   TreeItemCollapsibleState,
   TreeDataProvider,
   TextDocumentShowOptions,
@@ -57,10 +58,14 @@ interface SearchItem {
 }
 class AstGrepScanTreeItem extends TreeItem {
   constructor(public item: FileItem | SearchItem) {
-    let label = ''
+    let label
     let collapsibleState = TreeItemCollapsibleState.None
     if ('source' in item) {
-      label = item.source
+      const { start, end } = item.range
+      label = {
+        label: item.source,
+        highlights: [[start.character, end.character]]
+      } as TreeItemLabel
     } else {
       label = item.file
       collapsibleState = TreeItemCollapsibleState.Expanded
@@ -127,7 +132,7 @@ export class AstGrepSearchResultProvider
       const { start, end } = item.range
       return new AstGrepScanTreeItem({
         file: item.file,
-        source: item.text,
+        source: item.lines,
         range: new Range(
           new Position(start.line, start.column),
           new Position(end.line, end.column)


### PR DESCRIPTION
<img width="505" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/8e86188e-aa98-49a8-a853-e1f26b43577d">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f186fb9be93487b4613c6eeb5c6b58c056d0cb00.  | 
|--------|--------|

### Summary:
This PR enhances the `ast-grep-vscode` extension by adding line context to search results, achieved by modifying the `AstGrepScanTreeItem` and `AstGrepSearchResultProvider` classes in `src/extension.ts`.

**Key points**:
- Updated `AstGrepScanTreeItem` constructor in `src/extension.ts` to include a `TreeItemLabel` with highlights.
- Modified `AstGrepSearchResultProvider` to use `item.lines` instead of `item.text` when creating a new `AstGrepScanTreeItem`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
