### PR TITLE
feat: add file count badge to tree item

### DIFF
--- a/src/webview/SearchSidebar/SearchResultList/comps/TreeItem.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/TreeItem.tsx
@@ -4,6 +4,7 @@ import { useBoolean } from 'react-use'
 import type { SgSearch } from '../../../../types'
 import { CodeBlock } from './CodeBlock'
 import { FileLink } from './FileLink'
+import { VSCodeBadge } from '@vscode/webview-ui-toolkit/react'
 
 interface TreeItemProps {
   filePath: string
@@ -39,11 +40,12 @@ const TreeItem = ({ filePath, matches }: TreeItemProps) => {
           gap="4"
           px="2"
           alignItems="center"
+          justifyContent="space-between"
           h="22px"
           lineHeight="22px"
         >
           <FileLink filePath={filePath} />
-          <div>{matches.length.toString()}</div>
+          <VSCodeBadge>{matches.length}</VSCodeBadge>
         </HStack>
       </HStack>
 


### PR DESCRIPTION
<img width="450" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/641ccb5c-aa87-4765-a177-492b63239f08">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a19f22d2a1aa5da1bbb9d0f68cd3ce7c9b6400ef.  | 
|--------|--------|

### Summary:
This PR adds a file count badge to the `TreeItem` component by replacing the div that was displaying the match count with a `VSCodeBadge` and adjusting the layout.

**Key points**:
- Imported `VSCodeBadge` from `@vscode/webview-ui-toolkit/react` in `TreeItem.tsx`.
- Replaced div displaying match count with `VSCodeBadge`.
- Set `justifyContent` of parent `HStack` to `space-between`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
