### PR TITLE
feat: support simple mutli line highlight

### DIFF
--- a/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
@@ -9,15 +9,17 @@ const style = {
 
 function splitByHighLightToken(search: SgSearch) {
   const { start, end } = search.range
-  // TODO: multilines highlight
-  const { column: startColumn } = start
-  const { column: endColumn } = end
-
-  const startIdx = startColumn
-  const endIdx = endColumn
-
+  let startIdx = start.column
+  let endIdx = end.column
+  let displayLine = search.lines
+  // multiline matches!
+  if (start.line < end.line) {
+    displayLine = search.lines.split(/\r?\n/, 1)[0]
+    endIdx = displayLine.length
+  }
   return {
-    index: [startIdx, endIdx]
+    index: [startIdx, endIdx],
+    displayLine
   }
 }
 


### PR DESCRIPTION
Before
<img width="246" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/c5f76772-0ec2-451b-b7bc-0849e3dc007e">


After:
<img width="338" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/47dc84c4-32f5-46b6-a486-19008ecdf207">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a384d61ab684a85ef119a28aa192d8793246c6dd.  | 
|--------|--------|

### Summary:
This PR enhances the `splitByHighLightToken` function in `CodeBlock.tsx` to support highlighting the entire first line of multiline matches.

**Key points**:
- Modified `splitByHighLightToken` function in `CodeBlock.tsx`.
- Added handling for multiline matches.
- The entire first line of a multiline match is now highlighted.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
