### PR TITLE
feat: improve leading spaces handling

### DIFF
--- a/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
@@ -7,15 +7,24 @@ const style = {
   border: '1px solid var(--vscode-editor-findMatchHighlightBackground)'
 }
 
+const LEADING_SPACES_RE = /^\s*/
+
 function splitByHighLightToken(search: SgSearch) {
   const { start, end } = search.range
   let startIdx = start.column
   let endIdx = end.column
   let displayLine = search.lines
-  // multiline matches!
+  // multiline matches! only display the first line!
   if (start.line < end.line) {
     displayLine = search.lines.split(/\r?\n/, 1)[0]
     endIdx = displayLine.length
+  }
+  // strip leading spaces
+  const leadingSpaces = displayLine.match(LEADING_SPACES_RE)?.[0].length
+  if (leadingSpaces) {
+    displayLine = displayLine.substring(leadingSpaces)
+    startIdx -= leadingSpaces
+    endIdx -= leadingSpaces
   }
   return {
     index: [startIdx, endIdx],
@@ -27,9 +36,8 @@ interface CodeBlockProps {
   match: SgSearch
 }
 export const CodeBlock = ({ match }: CodeBlockProps) => {
-  const { file, lines } = match
-
-  const { index } = splitByHighLightToken(match)
+  const { file } = match
+  const { index, displayLine } = splitByHighLightToken(match)
 
   const startIdx = index[0]
   const endIdx = index[1]
@@ -47,9 +55,9 @@ export const CodeBlock = ({ match }: CodeBlockProps) => {
         openFile({ filePath: file, locationsToSelect: match.range })
       }}
     >
-      {startIdx <= 0 ? '' : lines.slice(0, startIdx)}
-      <span style={style}>{lines.slice(startIdx, endIdx)}</span>
-      {endIdx >= lines.length ? '' : lines.slice(endIdx)}
+      {displayLine.slice(0, startIdx)}
+      <span style={style}>{displayLine.slice(startIdx, endIdx)}</span>
+      {displayLine.slice(endIdx)}
     </Box>
   )
 }


### PR DESCRIPTION
Before:

<img width="387" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/17a30123-a112-4c0b-85ae-1636c31503dc">


After:

<img width="395" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/8b03935e-90d3-47ba-ab1c-44fe0d5d3418">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 07dd082521d6edb9065b1b09adeb75e9a1722e33.  | 
|--------|--------|

### Summary:
This PR improves the handling of leading spaces in the `CodeBlock` component by introducing a regex to match leading spaces and updating the `splitByHighLightToken` function and `CodeBlock` component accordingly.

**Key points**:
- Introduced a new constant `LEADING_SPACES_RE` to match leading spaces.
- Updated `splitByHighLightToken` function to strip leading spaces from `displayLine` and adjust `startIdx` and `endIdx`.
- Updated `CodeBlock` component to use `displayLine` for rendering.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
