### PR TITLE
feat: use `--vscode-sideBar-foreground` in sidebar

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -7,7 +7,7 @@
 
 body {
   /** Use important to override chakra styles */
-  color: var(--vscode-foreground) !important;
+  color: var(--vscode-sideBar-foreground) !important;
   font-size: var(--vscode-font-size) !important;
   font-weight: var(--vscode-font-weight) !important;
   font-family: var(--vscode-font-family) !important;


### PR DESCRIPTION
Use `--vscode-sideBar-foreground` instead of `--vscode-foreground` in sidebar

| | Builtin search | ast grep |
|-|-|-|
| Before | <img width="371" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/38436475/53a4183e-49d4-4c13-8e9a-0ab84bde941f"> | <img width="365" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/38436475/860ee153-3936-436c-ad21-17bba911a371"> |
| After | same as `before` | <img width="370" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/38436475/919a6004-22af-466e-bbc2-b90e521d7f0c"> |

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f222694d71789dbda9a0eaef6f40fc320a7a1328.  | 
|--------|--------|

### Summary:
This PR updates the color of the sidebar in `vscode.css` to use `--vscode-sideBar-foreground` for better UI consistency.

**Key points**:
- Changed color variable in `vscode.css` from `--vscode-foreground` to `--vscode-sideBar-foreground`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
