### PR TITLE
feat: support multiple line match indicator

### DIFF
--- a/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
@@ -27,20 +27,35 @@ function splitByHighLightToken(search: SgSearch) {
     endIdx -= leadingSpaces
   }
   return {
-    index: [startIdx, endIdx],
-    displayLine
+    startIdx,
+    endIdx,
+    displayLine,
+    lineSpan: end.line - start.line
   }
+}
+
+// this is also hardcoded in vscode
+const lineIndicatorStyle = {
+  margin: '0 7px 4px',
+  opacity: '0.7',
+  fontSize: '0.9em',
+  verticalAlign: 'bottom'
+}
+
+function MultiLineIndicator({ lineSpan }: { lineSpan: number }) {
+  if (lineSpan <= 0) {
+    return null
+  }
+  return <span style={lineIndicatorStyle}>+{lineSpan}</span>
 }
 
 interface CodeBlockProps {
   match: SgSearch
 }
 export const CodeBlock = ({ match }: CodeBlockProps) => {
-  const { file } = match
-  const { index, displayLine } = splitByHighLightToken(match)
+  const { startIdx, endIdx, displayLine, lineSpan } =
+    splitByHighLightToken(match)
 
-  const startIdx = index[0]
-  const endIdx = index[1]
   return (
     <Box
       flex="1"
@@ -52,9 +67,10 @@ export const CodeBlock = ({ match }: CodeBlockProps) => {
       height="22px"
       cursor="pointer"
       onClick={() => {
-        openFile({ filePath: file, locationsToSelect: match.range })
+        openFile({ filePath: match.file, locationsToSelect: match.range })
       }}
     >
+      <MultiLineIndicator lineSpan={lineSpan} />
       {displayLine.slice(0, startIdx)}
       <span style={style}>{displayLine.slice(startIdx, endIdx)}</span>
       {displayLine.slice(endIdx)}


### PR DESCRIPTION
<img width="390" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/479a8059-198e-4217-9398-cc03fff35490">


<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit d5e8c3c76343db8c0745fdc78d7878cfaae57a95.  | 
|--------|--------|

### Summary:
This PR introduces multiple line match indicators in the search results by updating the `splitByHighLightToken` function and adding a new `MultiLineIndicator` function in the `CodeBlock.tsx` file.

**Key points**:
- Updated `splitByHighLightToken` function in `CodeBlock.tsx` to return `startIdx`, `endIdx`, `displayLine`, and `lineSpan`.
- Added new function `MultiLineIndicator` to display the line span if it's more than 0.
- Updated `CodeBlock` component to include `MultiLineIndicator` and use `splitByHighLightToken` function to get the required values.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
