### PR TITLE
fix: text unreadable on most dark themes

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -7,7 +7,7 @@
 
 body {
   /** Use important to override chakra styles */
-  color: var(--vscode-sideBar-foreground) !important;
+  color: var(--vscode-foreground) !important;
   font-size: var(--vscode-font-size) !important;
   font-weight: var(--vscode-font-weight) !important;
   font-family: var(--vscode-font-family) !important;


### PR DESCRIPTION
# Related
closes #134 
#131 

# Details

In most cases, the color of builtin-search is `var(--vscode-foreground)`
However, in some themes, the color will be changed through the inline style. Because of the inline style, it is difficult to find the source.

![e49eb82fd98e72b79f31fe7e850f98af](https://github.com/ast-grep/ast-grep-vscode/assets/79413249/6da7bc02-ca9e-4176-836d-650f44c8408d)
![5632a192166ca986a6f57d960da9573a](https://github.com/ast-grep/ast-grep-vscode/assets/79413249/f0a0088a-3c8d-4c26-8e12-00376dc97a28)
![6cb7cc63d949b016e55b0e6fe27d1244](https://github.com/ast-grep/ast-grep-vscode/assets/79413249/9473a576-e155-4c65-a594-719f84c90e33)

I tried to search for relevant content in these theme github repos but it's hard to find it...

https://github.com/search?q=repo%3ABinaryify%2FOneDark-Pro+%23ABB2BF&type=code



In most cases, `var(--vscode-foreground)`  meets our need and is brighter.



<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit d25e3d48e2586fe830bbd0bb8538dd879a60326a.  | 
|--------|--------|

### Summary:
This PR improves text readability on dark themes by changing the body text color in `vscode.css` to `var(--vscode-foreground)`.

**Key points**:
- Changed the color of the body text in `vscode.css` from `var(--vscode-sideBar-foreground)` to `var(--vscode-foreground)`.
- This change improves text readability on dark themes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
