### PR TITLE
feat: add empty message

### DIFF
--- a/media/vscode.css
+++ b/media/vscode.css
@@ -11,6 +11,7 @@ body {
   font-size: var(--vscode-font-size) !important;
   font-weight: var(--vscode-font-weight) !important;
   font-family: var(--vscode-font-family) !important;
+  user-select: none;
 }
 
 ol,

--- a/src/webview/SearchSidebar/Empty.tsx
+++ b/src/webview/SearchSidebar/Empty.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react'
+import { VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+
+const style = {
+  color: 'var(--vscode-search-resultsInfoForeground)',
+  padding: '6px 22px 8px'
+}
+
+function Empty() {
+  return (
+    <div style={style}>
+      No results found. Review your patterns and check your gitignore files. -{' '}
+      <VSCodeLink href="https://ast-grep.github.io/guide/pattern-syntax.html">
+        Pattern Syntax
+      </VSCodeLink>
+    </div>
+  )
+}
+
+export default memo(Empty)

--- a/src/webview/SearchSidebar/index.tsx
+++ b/src/webview/SearchSidebar/index.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import { useDebounce, useLocalStorage } from 'react-use'
 import { UseDarkContextProvider } from './hooks/useDark'
 import LoadingBar from '../LoadingBar'
+import Empty from './Empty'
 
 const useSearchResult = (inputValue: string) => {
   const [searchResult, setResult] = useState<SgSearch[]>([])
@@ -46,6 +47,7 @@ export const SearchSidebar = () => {
         refreshResult={refreshSearchResult}
         setInputValue={setInputValue}
       />
+      {searchResult.length === 0 ? <Empty /> : null}
       <SearchResultList matches={searchResult} />
     </UseDarkContextProvider>
   )


### PR DESCRIPTION
fix #136 

<img width="454" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/2883231/0c987a14-590f-4f51-b9d5-2e53c254fceb">

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7b9900fde0daf1b75b1c690c6087ed0b7ca3b738.  | 
|--------|--------|

### Summary:
This PR adds an empty message feature that displays a message when no search results are found, by creating a new `Empty` component and using it in the `SearchSidebar`.

**Key points**:
- Added `user-select: none;` to `body` in `media/vscode.css`
- Created new `Empty` component in `src/webview/SearchSidebar/Empty.tsx` to display empty message
- Imported and used `Empty` component in `src/webview/SearchSidebar/index.tsx` when no search results are found


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
