### PR TITLE
feat(ui): provider message x results in y files

### DIFF
--- a/src/webview/SearchSidebar/Empty.tsx
+++ b/src/webview/SearchSidebar/Empty.tsx
@@ -3,7 +3,8 @@ import { VSCodeLink } from '@vscode/webview-ui-toolkit/react'
 
 const style = {
   color: 'var(--vscode-search-resultsInfoForeground)',
-  padding: '6px 22px 8px'
+  padding: '6px 22px 8px',
+  lineHeight: '1.4em'
 }
 
 function Empty() {

--- a/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
+++ b/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
@@ -7,7 +7,7 @@ const style = {
   lineHeight: '1.4em'
 }
 
-function Empty() {
+const Empty = memo(() => {
   return (
     <div style={style}>
       No results found. Review your patterns and check your gitignore files. -{' '}
@@ -16,6 +16,28 @@ function Empty() {
       </VSCodeLink>
     </div>
   )
+})
+
+interface SearchProviderMessageProps {
+  resultCount: number
+  fileCount: number
 }
 
-export default memo(Empty)
+const SearchProviderMessage = ({
+  resultCount,
+  fileCount
+}: SearchProviderMessageProps) => {
+  return (
+    <>
+      {resultCount === 0 ? (
+        <Empty />
+      ) : (
+        <div
+          style={style}
+        >{`${resultCount} results in ${fileCount} files`}</div>
+      )}
+    </>
+  )
+}
+
+export default SearchProviderMessage

--- a/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@chakra-ui/react'
 import type { SgSearch } from '../../../../types'
 import { openFile } from '../../postMessage'
+import { memo } from 'react'
 
 const style = {
   backgroundColor: 'var(--vscode-editor-findMatchHighlightBackground)',
@@ -52,7 +53,7 @@ function MultiLineIndicator({ lineSpan }: { lineSpan: number }) {
 interface CodeBlockProps {
   match: SgSearch
 }
-export const CodeBlock = ({ match }: CodeBlockProps) => {
+export const CodeBlock = memo(({ match }: CodeBlockProps) => {
   const { startIdx, endIdx, displayLine, lineSpan } =
     splitByHighLightToken(match)
 
@@ -76,4 +77,4 @@ export const CodeBlock = ({ match }: CodeBlockProps) => {
       {displayLine.slice(endIdx)}
     </Box>
   )
-}
+})

--- a/src/webview/SearchSidebar/SearchResultList/index.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/index.tsx
@@ -1,34 +1,18 @@
-import { useMemo, memo } from 'react'
+import { memo } from 'react'
 import { SgSearch } from '../../../types'
 import TreeItem from './comps/TreeItem'
-import { Box } from '@chakra-ui/react'
 
 interface SearchResultListProps {
-  matches: Array<SgSearch>
-}
-
-function groupBy(matches: SgSearch[]) {
-  const groups = new Map<string, SgSearch[]>()
-  for (const match of matches) {
-    if (!groups.has(match.file)) {
-      groups.set(match.file, [])
-    }
-    groups.get(match.file)?.push(match)
-  }
-  return groups
+  matches: Array<[string, SgSearch[]]>
 }
 
 const SearchResultList = ({ matches }: SearchResultListProps) => {
-  const groupedByFile = useMemo(() => {
-    return groupBy(matches)
-  }, [matches])
-
   return (
-    <Box mt="10">
-      {[...groupedByFile.entries()].map(([filePath, match]) => {
+    <div>
+      {matches.map(([filePath, match]) => {
         return <TreeItem filePath={filePath} matches={match} key={filePath} />
       })}
-    </Box>
+    </div>
   )
 }
 


### PR DESCRIPTION

<img width="482" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/79413249/79a3c8c8-376d-446f-bc29-731493bced67">

<!--
ELLIPSIS_HIDDEN
-->




| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 150daff46df8b8b6b9ed498276f650418d455b60.  | 
|--------|--------|

### Summary:
This PR introduces a new UI feature to display the number of search results in a certain number of files, refactors the code by moving the `groupBy` function, and optimizes the `CodeBlock` component with `React.memo`.

**Key points**:
- Introduced `SearchProviderMessage` component to display the number of search results in a certain number of files.
- Moved `groupBy` function from `SearchResultList` to `SearchSidebar`.
- Passed grouped results as a prop to `SearchResultList`.
- Wrapped `CodeBlock` component with `React.memo`.
- Disabled user selection in `media/vscode.css`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
