### PR TITLE
chore(deps): switch from gabrielbb/xvfb to coactions/setup-xvfb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Compile
         run: pnpm run compile
       - name: Run headless test
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: coactions/setup-xvfb@v1
         with:
           run: pnpm test


### PR DESCRIPTION
We have been using ([GabrielBB/xvfb-action](https://github.com/GabrielBB/xvfb-action/tree/master)) in our CI pipeline to perform headless tests, but it is now deprecated. 

We updated this dependency to version 1.6 in Dec 2022, and then it was deprecated in March 2023.
The author recommends switching to [coactions/setup-xvfb](https://github.com/coactions/setup-xvfb). 

This could potentially help with some inconsistencies in our CI tests.