### PR TITLE
Retry Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "lint-staged": "15.2.2",
     "mocha": "10.3.0",
     "prettier": "3.2.5",
+    "ts-retry": "^4.2.5",
     "typescript": "5.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "lint-staged": "15.2.2",
     "mocha": "10.3.0",
     "prettier": "3.2.5",
-    "ts-retry": "^4.2.5",
     "typescript": "5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ devDependencies:
   react-use:
     specifier: 17.5.0
     version: 17.5.0(react-dom@18.2.0)(react@18.2.0)
+  ts-retry:
+    specifier: ^4.2.5
+    version: 4.2.5
   tslib:
     specifier: 2.6.2
     version: 2.6.2
@@ -3743,6 +3746,10 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /ts-retry@4.2.5:
+    resolution: {integrity: sha512-dFBa4pxMBkt/bjzdBio8EwYfbAdycEAwe0KZgzlUKKwU9Wr1WErK7Hg9QLqJuDDYJXTW4KYZyXAyqYKOdO/ehA==}
     dev: true
 
   /tslib@1.14.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ devDependencies:
   react-use:
     specifier: 17.5.0
     version: 17.5.0(react-dom@18.2.0)(react@18.2.0)
-  ts-retry:
-    specifier: ^4.2.5
-    version: 4.2.5
   tslib:
     specifier: 2.6.2
     version: 2.6.2
@@ -3746,10 +3743,6 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
-
-  /ts-retry@4.2.5:
-    resolution: {integrity: sha512-dFBa4pxMBkt/bjzdBio8EwYfbAdycEAwe0KZgzlUKKwU9Wr1WErK7Hg9QLqJuDDYJXTW4KYZyXAyqYKOdO/ehA==}
     dev: true
 
   /tslib@1.14.1:

--- a/src/test/codefix.test.ts
+++ b/src/test/codefix.test.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 import {
   assertCodeActionArraysEqual,
-  getExpectedCodeActions,
   getActualCodeActions,
   getDocUri,
   testAndRetry
@@ -10,25 +9,35 @@ import {
 /** Actual tests */
 suite('Should get code action', () => {
   testAndRetry('Provide code action suggestions', async () => {
-    /* Calculate expected code actions */
     const docUri = getDocUri('test.ts')
     const range = new vscode.Range(
       new vscode.Position(0, 0),
       new vscode.Position(4, 1)
     )
-    const newText = `const AstGrepTest = {
+    /* Generate expected code actions */
+    const expectedTitle = 'Test rule for vscode extension'
+    const expectedKind = vscode.CodeActionKind.QuickFix
+    const expectedIsPreferred = true
+    const expectedNewText = `const AstGrepTest = {
   test() {
     console.log('Hello, world!')
   }
 }
 `
-    let expectedCodeActions = await getExpectedCodeActions(
-      docUri,
-      range,
-      newText
-    )
+    const edit = new vscode.WorkspaceEdit()
+    edit.replace(docUri, range, expectedNewText)
+    const expectedCodeActions = [
+      {
+        title: expectedTitle,
+        kind: expectedKind,
+        edit: edit,
+        isPreferred: expectedIsPreferred
+      } as vscode.CodeAction
+    ]
+
     /* Measure actual code actions */
-    let actualCodeActions = await getActualCodeActions(docUri, range)
-    assertCodeActionArraysEqual(expectedCodeActions, actualCodeActions, docUri)
+    const actualCodeActions = await getActualCodeActions(docUri, range)
+    /* Compare them */
+    assertCodeActionArraysEqual(actualCodeActions, expectedCodeActions, docUri)
   })
 })

--- a/src/test/diagnostics.test.ts
+++ b/src/test/diagnostics.test.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode'
 
-import { getDocUri, testDiagnostics, toRange } from './utils'
+import { getDocUri, testDiagnostics, toRange, testAndRetry } from './utils'
 
 suite('Should get diagnostics', () => {
   const docUri = getDocUri('test.ts')
-  test('Get ast-grep issues', async () => {
+  testAndRetry('Get ast-grep issues', async () => {
     await testDiagnostics(docUri, [
       {
         message: 'No console.log',

--- a/src/test/restart.test.ts
+++ b/src/test/restart.test.ts
@@ -1,13 +1,19 @@
 import * as vscode from 'vscode'
 
-import { getDocUri, sleep, testDiagnostics, toRange } from './utils'
+import {
+  getDocUri,
+  sleep,
+  testDiagnostics,
+  toRange,
+  testAndRetry
+} from './utils'
 
 suite('ast-grep.restartLanguageServer should work', () => {
   const docUri = getDocUri('test.ts')
   const sgConfigYml = getDocUri('sgconfig.yml')
   const tempSgConfigYml = getDocUri('_sgconfig.yml')
 
-  test('Delete or create the sgconfig.yml', async () => {
+  testAndRetry('Delete or create the sgconfig.yml', async () => {
     // remove configFile should receive no diagnostics
     await vscode.workspace.fs.rename(sgConfigYml, tempSgConfigYml)
     await vscode.commands.executeCommand('ast-grep.restartLanguageServer')

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -118,18 +118,20 @@ export function toRange(
  * @param docUri The URI of the document being tested
  */
 export function assertCodeActionArraysEqual(
-  actual: vscode.CodeAction[],
-  expected: vscode.CodeAction[],
+  actuals: vscode.CodeAction[],
+  expecteds: vscode.CodeAction[],
   docUri: vscode.Uri
 ): void {
-  assert.equal(actual.length, expected.length)
-  expected.forEach((expectedElement, i) => {
-    const actualElement = actual[i]
-    assert.equal(actualElement.title, expectedElement.title)
-    assert.equal(actualElement.isPreferred, expectedElement.isPreferred)
+  assert.equal(actuals.length, expecteds.length, 'Number of CodeActions differ')
+  expecteds.forEach((_, i) => {
+    const actual = actuals[i]
+    const expected = expecteds[i]
+    assert.equal(actual.title, expected.title, 'title')
+    assert.equal(actual.isPreferred, expected.isPreferred, 'isPreferred')
     assert.equal(
-      JSON.stringify(actualElement.edit?.get(docUri)),
-      JSON.stringify(expectedElement.edit?.get(docUri))
+      JSON.stringify(actual.edit?.get(docUri)),
+      JSON.stringify(expected.edit?.get(docUri)),
+      "CodeActions' edit texts differ"
     )
   })
 }
@@ -189,7 +191,7 @@ export function testAndRetry(
       }
     }
   }
-  let options = Object.assign({}, defaultRetryOptions, retryOptions)
+  const options = { ...defaultRetryOptions, ...retryOptions }
   return test(name, async () => {
     let p = retry.retry(wrapped, options)
     p.finally(() => {


### PR DESCRIPTION
CI tests have been inconsistent, sometimes failing and sometimes succeeding. This is due to (at least) a timing issue where calls to `vscode.commands.executeCommand` can fail with a cryptic error message saying that it has been 'Canceled'. This PR allows us to easily retry tests a few times if they fail. 

The alternative we have been working with is to just sleep for longer and longer periods hoping that the extension host will be ready. But with this approach there is a direct tradeoff between how long tests take and how certain we are that they didn't fail because of this timing issue. With the retry approach, we can have both high reliability and quick tests.