### PR TITLE
perf: reduce unnecessary re-renders while streaming results

### DIFF
--- a/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
+++ b/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
@@ -52,7 +52,7 @@ function Empty({ query }: { query: SearchQuery }) {
 
 interface SearchProviderMessageProps {
   query: SearchQuery
-  results: [string, DisplayResult[]][]
+  results: Map<string, DisplayResult[]>
   error: Error | null
 }
 
@@ -74,8 +74,11 @@ const SearchProviderMessage = memo(
         </div>
       )
     }
-    const resultCount = results.reduce((a, l) => a + l[1].length, 0)
-    const fileCount = results.length
+    let resultCount = 0
+    for (const files of results.values()) {
+      resultCount += files.length
+    }
+    const fileCount = results.size
     return (
       <>
         {resultCount === 0 ? (

--- a/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { memo, useCallback } from 'react'
 import type { DisplayResult } from '../../../../types'
 import { openAction } from '../../../hooks/useSearch'
 import * as stylex from '@stylexjs/stylex'
@@ -68,7 +68,7 @@ function Highlight({
 interface CodeBlockProps {
   match: DisplayResult
 }
-export const CodeBlock = ({ match }: CodeBlockProps) => {
+export const CodeBlock = memo(({ match }: CodeBlockProps) => {
   const { startIdx, endIdx, displayLine, lineSpan, file, range } = match
   const onClick = useCallback(() => {
     openAction({ filePath: file, locationsToSelect: range })
@@ -82,4 +82,4 @@ export const CodeBlock = ({ match }: CodeBlockProps) => {
       {displayLine.slice(endIdx)}
     </div>
   )
-}
+})

--- a/src/webview/SearchSidebar/SearchResultList/comps/TreeItem.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/comps/TreeItem.tsx
@@ -112,7 +112,7 @@ interface TreeItemProps {
   matches: DisplayResult[]
 }
 
-const TreeItem = ({ filePath, matches }: TreeItemProps) => {
+const TreeItem = memo(({ filePath, matches }: TreeItemProps) => {
   const [isExpanded, toggleIsExpanded] = useBoolean(true)
   const { isScrolled, ref } = useStickyShadow()
 
@@ -145,5 +145,5 @@ const TreeItem = ({ filePath, matches }: TreeItemProps) => {
       </ul>
     </div>
   )
-}
+})
 export default TreeItem

--- a/src/webview/SearchSidebar/SearchResultList/index.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/index.tsx
@@ -6,7 +6,7 @@ interface SearchResultListProps {
   matches: Map<string, DisplayResult[]>
 }
 
-const SearchResultList = memo(({ matches }: SearchResultListProps) => {
+const SearchResultList = ({ matches }: SearchResultListProps) => {
   return (
     <div style={{ flexGrow: '1', overflowY: 'scroll' }}>
       {Array.from(matches.entries()).map(([filePath, match]) => {
@@ -14,6 +14,6 @@ const SearchResultList = memo(({ matches }: SearchResultListProps) => {
       })}
     </div>
   )
-})
+}
 
 export default memo(SearchResultList)

--- a/src/webview/SearchSidebar/SearchResultList/index.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/index.tsx
@@ -3,17 +3,17 @@ import { DisplayResult } from '../../../types'
 import TreeItem from './comps/TreeItem'
 
 interface SearchResultListProps {
-  matches: Array<[string, DisplayResult[]]>
+  matches: Map<string, DisplayResult[]>
 }
 
-const SearchResultList = ({ matches }: SearchResultListProps) => {
+const SearchResultList = memo(({ matches }: SearchResultListProps) => {
   return (
     <div style={{ flexGrow: '1', overflowY: 'scroll' }}>
-      {matches.map(([filePath, match]) => {
+      {Array.from(matches.entries()).map(([filePath, match]) => {
         return <TreeItem filePath={filePath} matches={match} key={filePath} />
       })}
     </div>
   )
-}
+})
 
 export default memo(SearchResultList)

--- a/src/webview/hooks/useSearch.tsx
+++ b/src/webview/hooks/useSearch.tsx
@@ -151,12 +151,12 @@ export function openAction(payload: OpenPayload) {
 }
 
 export const useSearchResult = () => {
-  useSyncExternalStore(subscribe, getSnapshot)
+  let groupedByFileSearchResult = useSyncExternalStore(subscribe, getSnapshot)
   return {
     queryInFlight,
     searching,
     searchError,
-    groupedByFileSearchResult: grouped,
+    groupedByFileSearchResult,
   }
 }
 export { postSearch }


### PR DESCRIPTION
In this PR, we changed the type of `grouped` to `Map`, which can improve the performance of the merging operation. When a group is not changed by a streaming event, `merge` function will now reuse the existing group contents, which can reduce re-renders of that group.