### PR TITLE
Do not automatically start LSP client/server if no sgconfig.yml is found

### DIFF
--- a/src/extension/lsp.ts
+++ b/src/extension/lsp.ts
@@ -47,6 +47,20 @@ async function testBinaryExist() {
   })
 }
 
+async function fileExists(pathFromRoot: string): Promise<boolean> {
+  const workspaceFolders = workspace.workspaceFolders
+  if (!workspaceFolders) {
+    return false
+  }
+  const uri = Uri.joinPath(workspaceFolders[0].uri, pathFromRoot)
+  try {
+    await workspace.fs.stat(uri)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /**
  * Set up language server/client
  */
@@ -109,8 +123,11 @@ export async function activateLsp(context: ExtensionContext) {
     clientOptions,
   )
 
-  // Start the client. This will also launch the server
-  client.start()
+  // Automatically start the client only if we can find a config file
+  if (await fileExists('sgconfig.yml')) {
+    // Start the client. This will also launch the server
+    client.start()
+  }
 }
 
 async function restart(): Promise<void> {


### PR DESCRIPTION
The motivation is to prevent the extension from warning the user about a configuration error, when the user never intended to use ast-grep as a linter in the current workspace.

We will use the presence of sgconfig.yml as a proxy for the user's desire to use the ast-grep extension as a linter. Currently we just check the workspace root but in the future we will look at the vscode setting of `astGrep.configPath`.

This change prevents the **initial** call to `client.start()` on extension activation if sgconfig.yml is missing. That means that subsequent calls to restart the LSP server through the command  `ast-grep.restartLanguageServer` will still call `client.start()` and will show the user an error about not finding the config.