### PR TITLE
feat: implement Replace All action

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,13 @@ export interface ChildToParent {
     inputValue: string
     rewrite: string
   }>
+  applyEdit: readonly {
+    filePath: string
+    replacements: readonly {
+      range: RangeInfo
+      text: string
+    }[]
+  }[]
 }
 
 export type Definition = {

--- a/src/webview/SearchSidebar/SearchWidgetContainer/SearchWidget.tsx
+++ b/src/webview/SearchSidebar/SearchWidgetContainer/SearchWidget.tsx
@@ -1,9 +1,10 @@
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import {
   useSearchField,
   refreshResult,
   hasInitialRewrite,
 } from '../../hooks/useQuery'
-import { useSearchResult } from '../../hooks/useSearch'
+import { useSearchResult, replaceAll } from '../../hooks/useSearch'
 import { SearchInput } from './SearchInput'
 import { useBoolean } from 'react-use'
 import { VscChevronRight, VscChevronDown, VscReplaceAll } from 'react-icons/vsc'
@@ -39,23 +40,7 @@ const styles = stylex.create({
     gap: 4,
   },
   replaceAll: {
-    cursor: 'pointer',
     height: 24,
-    marginRight: -2,
-    padding: '0 3px',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: '5px',
-    background: 'transparent',
-    color: 'inherit',
-    ':hover': {
-      background: 'var(--vscode-toolbar-hoverBackground)',
-    },
-    ':disabled': {
-      color: 'var(--vscode-disabledForeground)',
-      pointerEvents: 'none',
-    },
   },
 })
 
@@ -72,9 +57,15 @@ function ReplaceBar() {
         onChange={setRewrite}
         onKeyEnterUp={refreshResult}
       />
-      <button {...stylex.props(styles.replaceAll)} disabled={disabled}>
+      <VSCodeButton
+        title="Replace All"
+        appearance="icon"
+        disabled={disabled}
+        onClick={() => replaceAll()}
+        {...stylex.props(styles.replaceAll)}
+      >
         <VscReplaceAll />
-      </button>
+      </VSCodeButton>
     </div>
   )
 }

--- a/src/webview/hooks/useSearch.tsx
+++ b/src/webview/hooks/useSearch.tsx
@@ -7,6 +7,7 @@ import {
   commitChange,
   childPort,
   type RangeInfo,
+  applyEdit,
 } from '../postMessage'
 import { useSyncExternalStore } from 'react'
 import type { SearchQuery } from './useQuery'
@@ -211,6 +212,21 @@ export function acceptFileChanges(filePath: string) {
       range: c.range,
     })),
   })
+}
+
+/**
+ * Replace all matches in the search results
+ */
+export function replaceAll() {
+  applyEdit(
+    grouped.map(([filePath, diffs]) => ({
+      filePath,
+      replacements: diffs.map(d => ({
+        range: d.range,
+        text: d.replacement!,
+      })),
+    })),
+  )
 }
 
 export function dismissOneMatch(match: DisplayResult) {

--- a/src/webview/postMessage.ts
+++ b/src/webview/postMessage.ts
@@ -34,3 +34,7 @@ export function dismissDiff(data: ChildToParent['dismissDiff']) {
 export function commitChange(diff: ChildToParent['commitChange']) {
   childPort.postMessage('commitChange', diff)
 }
+
+export function applyEdit(payload: ChildToParent['applyEdit']) {
+  childPort.postMessage('applyEdit', payload)
+}


### PR DESCRIPTION
Implement "Replace All" action on the search panel

<img width="438" alt="image" src="https://github.com/ast-grep/ast-grep-vscode/assets/8225666/b83a8f12-5c5e-49d9-b24c-54681c96f5fb">

Implementation:

- Add rpc function `applyEdit` that uses [`vscode.workspace.applyEdit` API](https://code.visualstudio.com/api/references/vscode-api#workspace.applyEdit) to apply batch text edit across multiple files
- When "Replace All" button is clicked, call `applyEdit` rpc with all the replacements in search results. *This does not automatically save the updated files

Also changed:

- Use [`<VSCodeButton>` component](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/src/button/README.md) instead of `<button>` element to make styling easier
- Add "Replace All" title to the button