### PR TITLE
feat(command): ast-grep.executeAutofix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "contributes": {
     "commands": [
       {
+        "command": "ast-grep.executeAutofix",
+        "title": "executeAutofix",
+        "category": "ast-grep"
+      },
+      {
         "command": "ast-grep.restartLanguageServer",
         "title": "restart Language Server",
         "category": "ast-grep"

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "commands": [
       {
         "command": "ast-grep.executeAutofix",
-        "title": "executeAutofix",
+        "title": "Fix all auto-fixable Problems",
         "category": "ast-grep"
       },
       {
         "command": "ast-grep.restartLanguageServer",
-        "title": "restart Language Server",
+        "title": "Restart Language Server",
         "category": "ast-grep"
       },
       {

--- a/src/extension/lsp.ts
+++ b/src/extension/lsp.ts
@@ -69,6 +69,7 @@ async function applyAllFixes() {
     uri: textEditor.document.uri.toString(),
     version: textEditor.document.version,
     text: textEditor.document.getText(),
+    languageId: textEditor.document.languageId,
   }
   const params = {
     command: 'ast-grep.applyAllFixes',

--- a/src/extension/lsp.ts
+++ b/src/extension/lsp.ts
@@ -1,4 +1,11 @@
-import { workspace, type ExtensionContext, window, commands, Uri } from 'vscode'
+import {
+  env,
+  workspace,
+  type ExtensionContext,
+  window,
+  commands,
+  Uri,
+} from 'vscode'
 import {
   LanguageClient,
   type LanguageClientOptions,
@@ -55,6 +62,9 @@ async function applyAllFixes() {
   if (!textEditor) {
     return
   }
+  if (!client) {
+    return
+  }
   const textDocument = {
     uri: textEditor.document.uri.toString(),
     version: textEditor.document.version,
@@ -65,9 +75,21 @@ async function applyAllFixes() {
     arguments: [textDocument],
   }
   client.sendRequest(ExecuteCommandRequest.type, params).then(undefined, () => {
-    void window.showErrorMessage(
-      'Failed to apply Ast-grep fixes to the document. Please consider upgrading ast-grep version or opening an issue with steps to reproduce.',
-    )
+    const actionButtonName = 'Upgrade Document'
+    window
+      .showErrorMessage(
+        'Failed to apply Ast-grep fixes to the document. Please consider upgrading ast-grep version or opening an issue with steps to reproduce.',
+        actionButtonName,
+      )
+      .then(value => {
+        if (value === actionButtonName) {
+          env.openExternal(
+            Uri.parse(
+              'https://ast-grep.github.io/guide/quick-start.html#installation',
+            ),
+          )
+        }
+      })
   })
 }
 

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -16,7 +16,7 @@ export function activateSearch(context: ExtensionContext) {
 
 // biome-ignore lint/suspicious/noExplicitAny: todo
 function findInFolder(data: any) {
-  const workspacePath = workspace.workspaceFolders?.[0].uri.fsPath
+  const workspacePath = workspace.workspaceFolders?.[0]?.uri?.fsPath
   // compute relative path to the workspace folder
   const relative = workspacePath && path.relative(workspacePath, data.fsPath)
   if (!relative) {


### PR DESCRIPTION
the same feature as vscode-eslint
![image](https://github.com/ast-grep/ast-grep-vscode/assets/79413249/75380344-5aeb-4ab2-9ae4-ef6a78bc741e)

![image](https://github.com/ast-grep/ast-grep-vscode/assets/79413249/6e470767-0d13-44e1-8039-56fb7aa5e6ef)



