### PR TITLE
fix: focus lost if active diff tab is closed

### DIFF
--- a/src/extension/preview.ts
+++ b/src/extension/preview.ts
@@ -154,7 +154,7 @@ function closeAllDiffs() {
   for (const tab of tabs) {
     const input = tab.input
     if (input instanceof TabInputTextDiff && isSgPreviewUri(input.modified)) {
-      window.tabGroups.close(tab)
+      window.tabGroups.close(tab, true)
     }
   }
 }


### PR DESCRIPTION
Fixes this:


https://github.com/ast-grep/ast-grep-vscode/assets/49969959/b2176628-047e-4db7-ab3c-65e180405aca

