### PR TITLE
chore: specify package manager and its version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ast-grep-vscode",
   "version": "0.1.7",
   "description": "ast-grep VSCode is a structural search and replace extension for many languages.",
+  "packageManager": "pnpm@9.0.4",
   "keywords": [
     "ast",
     "ast-grep",


### PR DESCRIPTION
Currently, this project uses pnpm@9 (see its lock file version), but hasn't specified its package manager version. To avoid some PR changes that have lock file version changes, we should specify it.