### PR TITLE
feat: auto detect globs

### DIFF
--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -127,7 +127,13 @@ export function buildCommand(query: SearchQuery) {
   if (query.lang) {
     args.push('--lang', query.lang)
   }
-  args.push(...includeFile.split(',').filter(Boolean))
+  const validIncludeFile = includeFile.split(',').filter(Boolean)
+  const hasGlobPattern = validIncludeFile.some(i => i.includes('*'))
+  if (hasGlobPattern) {
+    args.push(...validIncludeFile.map(i => `--globs=${i}`))
+  } else {
+    args.push(...validIncludeFile)
+  }
   console.debug('running', query, command, args)
   // TODO: multi-workspaces support
   return spawn(command, args, {

--- a/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
+++ b/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
@@ -74,7 +74,7 @@ function Empty({ query }: { query: SearchQuery }) {
         {query.includeFile.length ? (
           <li>
             If you're using glob patterns in the include file, please ensure
-            that your version of ast-grep is above{' '}
+            that your version of ast-grep is above
             <code style={codeStyle}>v0.28.0</code>.
           </li>
         ) : null}

--- a/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
+++ b/src/webview/SearchSidebar/SearchProviderMessage/index.tsx
@@ -71,6 +71,13 @@ function Empty({ query }: { query: SearchQuery }) {
             .
           </li>
         ) : null}
+        {query.includeFile.length ? (
+          <li>
+            If you're using glob patterns in the include file, please ensure
+            that your version of ast-grep is above{' '}
+            <code style={codeStyle}>v0.28.0</code>.
+          </li>
+        ) : null}
         <li>
           Adjust your gitignore files.{' '}
           <VSCodeLink href="https://ast-grep.github.io/reference/cli/run.html#no-ignore-file-type">

--- a/src/webview/SearchSidebar/SearchWidgetContainer/IncludeFile.tsx
+++ b/src/webview/SearchSidebar/SearchWidgetContainer/IncludeFile.tsx
@@ -25,7 +25,7 @@ export default function IncludeFile({
       <h4 style={titleStyle}>files to include</h4>
       <SearchInput
         isSingleLine={true}
-        placeholder="e.g. src, packages. No glob pattern"
+        placeholder="e.g. src, packages, src/**/*.ts"
         value={includeFile}
         onChange={setIncludeFile}
         onKeyEnterUp={refreshResult}


### PR DESCRIPTION
Now ast-grep vscode supports `globs` when binary version is above `v0.28.0`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for auto-detecting and using glob patterns in ast-grep VSCode extension when binary version is 0.28.0 or higher.
> 
>   - **Behavior**:
>     - Adds `detectSgVersion()` in `common.ts` to determine the binary version.
>     - Updates `buildCommand()` in `search.ts` to include glob patterns if supported.
>     - Modifies `IncludeFile.tsx` to update placeholder text and handle glob input based on version.
>   - **UI**:
>     - Adds `useDetectGlobFeatureAvailable()` in `useFeature.tsx` to check glob feature availability.
>     - Updates `useQuery.tsx` and `useSearch.tsx` to handle glob state in search queries.
>   - **Dependencies**:
>     - Adds `compare-versions` to `package.json` for version comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ast-grep%2Fast-grep-vscode&utm_source=github&utm_medium=referral)<sup> for 09130bf24d56e39ff742454a2eae00bb53d43112. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->