### PR TITLE
Remove shell when calling spawn

### DIFF
--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -139,7 +139,6 @@ export function buildCommand(query: SearchQuery) {
   // TODO: multi-workspaces support
   return spawn(command, args, {
     cwd: uris[0],
-    shell: process.platform === 'win32', // it is safe because it is end user input
   })
 }
 


### PR DESCRIPTION
This fixes an issue where parts of the pattern are not passed when searching on Windows.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `shell` option from `spawn` in `buildCommand` in `search.ts` to fix pattern passing issue on Windows.
> 
>   - **Behavior**:
>     - Remove `shell` option from `spawn` call in `buildCommand` in `search.ts`, affecting command execution on Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ast-grep%2Fast-grep-vscode&utm_source=github&utm_medium=referral)<sup> for 07d04a0bc52a532e63df6ce31894d099329bdac7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->