### PR TITLE
fix: spawn shell option in windows

### DIFF
--- a/src/extension/common.ts
+++ b/src/extension/common.ts
@@ -53,7 +53,9 @@ export async function testBinaryExist(command: string) {
       ['-h'],
       {
         // for windows
-        shell: process.platform === 'win32' && !command.endsWith('.exe'),
+        shell:
+          process.platform === 'win32' &&
+          !command.toLowerCase().endsWith('.exe'),
         cwd: uris[0],
       },
       err => {

--- a/src/extension/common.ts
+++ b/src/extension/common.ts
@@ -32,7 +32,10 @@ export async function detectDefaultBinaryAtStart() {
 }
 
 export function resolveBinary() {
-  const config = workspace.getConfiguration('astGrep').get('serverPath', '')
+  const config = workspace
+    .getConfiguration('astGrep')
+    .get('serverPath', '')
+    .trim()
   if (!config) {
     return defaultBinary
   }
@@ -41,7 +44,8 @@ export function resolveBinary() {
 
 export async function testBinaryExist(command: string) {
   // windows user may input space in command
-  const normalizedCommand = /\s/.test(command.trim()) ? `"${command}"` : command
+  const normalizedCommand =
+    /\s/.test(command) && !command.endsWith('.exe') ? `"${command}"` : command
   const uris = workspace.workspaceFolders?.map(i => i.uri?.fsPath) ?? []
   return new Promise(r => {
     execFile(
@@ -49,7 +53,7 @@ export async function testBinaryExist(command: string) {
       ['-h'],
       {
         // for windows
-        shell: process.platform === 'win32',
+        shell: process.platform === 'win32' && !command.endsWith('.exe'),
         cwd: uris[0],
       },
       err => {

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -114,6 +114,9 @@ export function buildCommand(query: SearchQuery) {
     return
   }
   const command = resolveBinary()
+  // windows user may input space in command
+  const normalizedCommand =
+    /\s/.test(command) && !command.endsWith('.exe') ? `"${command}"` : command
   const uris = workspace.workspaceFolders?.map(i => i.uri?.fsPath) ?? []
   const args = ['run', '--pattern', pattern, '--json=stream']
   if (query.selector) {
@@ -135,9 +138,11 @@ export function buildCommand(query: SearchQuery) {
   } else {
     args.push(...validIncludeFile)
   }
-  console.debug('running', query, command, args)
+  console.debug('running', query, normalizedCommand, args)
   // TODO: multi-workspaces support
-  return spawn(command, args, {
+  return spawn(normalizedCommand, args, {
+    // for windows
+    shell: process.platform === 'win32' && !command.endsWith('.exe'),
     cwd: uris[0],
   })
 }

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -142,7 +142,8 @@ export function buildCommand(query: SearchQuery) {
   // TODO: multi-workspaces support
   return spawn(normalizedCommand, args, {
     // for windows
-    shell: process.platform === 'win32' && !command.endsWith('.exe'),
+    shell:
+      process.platform === 'win32' && !command.toLowerCase().endsWith('.exe'),
     cwd: uris[0],
   })
 }


### PR DESCRIPTION
Closes #235

After this PR, Windows ast-grep VS Code extension should be able to use `ast-grep` if available in terminal (typically installed via `npm i @ast-grep/cli -g`), or `astGrep.serverPath` if set by user, with or without space, .exe or .cmd or shell script.

### Dev notes

It seems in Windows, for `execFile()`, `exec()` and `spawn()` of [`child_process`](https://nodejs.org/api/child_process.html):

- Space:
  - If command contains space, we must either use `{ shell: false }` with command NOT wrapped in quotes, or `{ shell: true }` with command wrapped in quotes
  - If command does not contains space, we may use either `{ shell: true }` or `{ shell: false }`
- Executable type:
  - If command is a Batch/Shell/PowerShell script, we must use `{ shell: true }`
  - If command is an .exe, we may use either `{ shell: true }` or `{ shell: false }`
  - Checking if command ends with .bat/.cmd/.ps1\*/.sh or .exe could tell whether command is a Batch/Shell/PowerShell script or an executable file, but note that it may also be an alias to any of those and may not end with its corresponding extension
- Prefer `{ shell: false }`, unless we have to use `{ shell: true }`
- Other info regarding Windows shell: 
  - When [`{ shell: true }`](https://nodejs.org/api/child_process.html#default-windows-shell), node (used by Electron and by VS Code) uses '/bin/sh' on Unix, `process.env.ComSpec` on Windows by default. And `process.env.ComSpec` is `C:\WINDOWS\system32\cmd.exe` (not PowerShell) by default
  - .ps1 files are PowerShell scripts, not runnable in cmd, Batch/Shell scripts are OK in cmd
  - When npm-installed globally, `ast-grep` is pointed to `C:\Program Files\nodejs\ast-grep.ps1` in PowerShell; `C:\Program Files\nodejs\ast-grep` and `C:\Program Files\nodejs\ast-grep.cmd` in cmd and git bash

So the best practice on windows seems to be:

- Only when command ends with ".exe", we use `{ shell: false }`.
- Otherwise use `{ shell: true }`, only in this case (and not in the above ".exe" case), if command contains space, we wrap it in quotes.

<details>
  <summary>You can try this code to see yourself</summary>

```js
const { execFile } = require("child_process");

function runCommand(command, args, options) {
  execFile(command, args, options, (err, stdout, stderr) => {
    // if (err) {
    //   console.log(`${command} ${options.shell ? "shell" : "no shell"}: Error`);
    // }
    // if (stdout) {
    //   console.log(`${command} ${options.shell ? "shell" : "no shell"}: STDOUT`);
    // }
    // if (stderr) {
    //   console.log(`${command} ${options.shell ? "shell" : "no shell"}: STDERR`);
    // }
    console.log(`${command} ${options.shell ? "shell" : "no shell"}: ${!err}`);
  });
}

try {
  runCommand("ast-grep", ["-h"], { shell: true });
  runCommand("ast-grep", ["-h"], { shell: false });

  // runCommand("C:\\Program Files\\nodejs\\ast-grep", ["-h"], { shell: true });
  // runCommand("C:\\Program Files\\nodejs\\ast-grep", ["-h"], { shell: false });

  // runCommand('"C:\\Program Files\\nodejs\\ast-grep"', ["-h"], { shell: true });
  // runCommand('"C:\\Program Files\\nodejs\\ast-grep"', ["-h"], { shell: false });

  // runCommand("C:\\Program Files\\nodejs\\ast-grep.cmd", ["-h"], {
  //   shell: true,
  // });
  // runCommand("C:\\Program Files\\nodejs\\ast-grep.cmd", ["-h"], {
  //   shell: false,
  // });

  // runCommand('"C:\\Program Files\\nodejs\\ast-grep.cmd"', ["-h"], {
  //   shell: true,
  // });
  // runCommand('"C:\\Program Files\\nodejs\\ast-grep.cmd"', ["-h"], {
  //   shell: false,
  // });

  // runCommand(
  //   "C:\\Program Files\\nodejs\\node_modules\\@ast-grep\\cli\\ast-grep.exe",
  //   ["-h"],
  //   { shell: true }
  // );
  // runCommand(
  //   "C:\\Program Files\\nodejs\\node_modules\\@ast-grep\\cli\\ast-grep.exe",
  //   ["-h"],
  //   { shell: false }
  // );

  // runCommand(
  //   '"C:\\Program Files\\nodejs\\node_modules\\@ast-grep\\cli\\ast-grep.exe"',
  //   ["-h"],
  //   { shell: true }
  // );
  // runCommand(
  //   '"C:\\Program Files\\nodejs\\node_modules\\@ast-grep\\cli\\ast-grep.exe"',
  //   ["-h"],
  //   { shell: false }
  // );
} catch {}
```

</details>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Windows command execution for `ast-grep` by adjusting `shell` options based on command type and spaces in `common.ts` and `search.ts`.
> 
>   - **Behavior**:
>     - Fixes command execution in Windows for `ast-grep` by adjusting `shell` option in `execFile()` and `spawn()` based on command type and spaces.
>     - Commands ending with `.exe` use `{ shell: false }`, others use `{ shell: true }` with spaces wrapped in quotes.
>   - **Functions**:
>     - Updates `testBinaryExist()` in `common.ts` to normalize commands and set `shell` option based on command type.
>     - Updates `buildCommand()` in `search.ts` to normalize commands and set `shell` option based on command type.
>   - **Misc**:
>     - Trims `serverPath` configuration in `resolveBinary()` in `common.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ast-grep%2Fast-grep-vscode&utm_source=github&utm_medium=referral)<sup> for 9ae036ccb6c765c49d76b967534dc3c0b10292c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trimming of configuration values to eliminate unwanted whitespace.
  - Refined command normalization for Windows, ensuring commands with spaces are managed correctly.
  - Adjusted shell execution handling to improve reliability when dealing with specific command formats on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->