### PR TITLE
Add support for empty replace in search

### DIFF
--- a/src/extension/preview.ts
+++ b/src/extension/preview.ts
@@ -212,7 +212,15 @@ async function onReplaceAll(payload: ChildToParent['replaceAll']) {
   if (confirmed !== 'Replace') {
     return
   }
-  const { id, pattern, rewrite, selector, strictness, lang } = payload
+  const {
+    id,
+    pattern,
+    rewrite,
+    selector,
+    strictness,
+    lang,
+    allowEmptyReplace,
+  } = payload
   for (const change of payload.changes) {
     // TODO: chunk change
     await onCommitChange({
@@ -222,13 +230,22 @@ async function onReplaceAll(payload: ChildToParent['replaceAll']) {
       selector,
       strictness,
       lang,
+      allowEmptyReplace,
       ...change,
     })
   }
 }
 
 async function onCommitChange(payload: ChildToParent['commitChange']) {
-  const { filePath, pattern, rewrite, strictness, selector, lang } = payload
+  const {
+    filePath,
+    pattern,
+    rewrite,
+    strictness,
+    selector,
+    lang,
+    allowEmptyReplace,
+  } = payload
   const fileUri = workspaceUriFromFilePath(filePath)
   if (!fileUri) {
     return
@@ -240,6 +257,7 @@ async function onCommitChange(payload: ChildToParent['commitChange']) {
     strictness,
     selector,
     lang,
+    allowEmptyReplace,
     includeFile: filePath,
   })
 }

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -80,7 +80,7 @@ export function splitByHighLightToken(search: SgSearch): DisplayResult {
 }
 
 function handleReplacement(replacement?: string) {
-  if (replacement) {
+  if (typeof replacement === 'string') {
     return { replacement }
   }
   return {}
@@ -127,6 +127,8 @@ export function buildCommand(query: SearchQuery) {
   }
   if (query.rewrite) {
     args.push('--rewrite', query.rewrite)
+  } else {
+    args.push('--rewrite=""')
   }
   if (strictness && strictness !== 'smart') {
     args.push('--strictness', strictness)

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -127,7 +127,8 @@ export function buildCommand(query: SearchQuery) {
   }
   if (query.rewrite) {
     args.push('--rewrite', query.rewrite)
-  } else {
+  } else if (query.allowEmptyReplace) {
+    // the empty string must be passed in this format, otherwise the cli will not accept the empty string
     args.push('--rewrite=""')
   }
   if (strictness && strictness !== 'smart') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ interface SearchQueryBasic {
   strictness: string
   selector: string
   lang: string
+  allowEmptyReplace: boolean
 }
 
 export interface SearchQuery extends SearchQueryBasic {

--- a/src/webview/SearchSidebar/SearchResultList/Actions.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/Actions.tsx
@@ -62,7 +62,7 @@ export function MatchActions({ match }: ActionsProps) {
   return (
     <ul {...stylex.props(styles.list)} role="toolbar">
       {/* VSCode supports shortcut Replace (⇧⌘1)*/}
-      {match.replacement ? (
+      {typeof match.replacement === 'string' ? (
         <li {...stylex.props(styles.action)} onClick={onClick}>
           <VscReplace role="button" title="Replace" tabIndex={0} />
         </li>

--- a/src/webview/SearchSidebar/SearchResultList/CodeBlock.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/CodeBlock.tsx
@@ -54,7 +54,7 @@ function Highlight({
   replacement,
 }: DisplayResult) {
   const matched = displayLine.slice(startIdx, endIdx)
-  if (replacement) {
+  if (typeof replacement === 'string') {
     const displayDiff = replacement.split(/\r?\n/, 1)[0]
     return (
       <>

--- a/src/webview/SearchSidebar/SearchResultList/TreeHeader.tsx
+++ b/src/webview/SearchSidebar/SearchResultList/TreeHeader.tsx
@@ -63,7 +63,7 @@ export default function TreeHeader({
   isScrolled,
 }: TreeHeaderProps) {
   const { file: filePath, language } = matches[0]
-  const hasReplace = Boolean(matches[0].replacement)
+  const hasReplace = typeof matches[0].replacement === 'string'
   const [active, setActive] = useActiveItem(matches)
   const styleProps = stylex.props(
     styles.fileName,

--- a/src/webview/SearchSidebar/SearchWidgetContainer/PatternConfig.tsx
+++ b/src/webview/SearchSidebar/SearchWidgetContainer/PatternConfig.tsx
@@ -3,8 +3,13 @@ import {
   VSCodeDropdown,
   VSCodeOption,
   VSCodeLink,
+  VSCodeCheckbox,
 } from '@vscode/webview-ui-toolkit/react'
-import { usePatternConfig, useSearchField } from '../../hooks/useQuery'
+import {
+  useBoolean,
+  usePatternConfig,
+  useSearchField,
+} from '../../hooks/useQuery'
 import { useCallback } from 'react'
 
 const titleStyle = {
@@ -29,6 +34,9 @@ function Link({ href }: { href: string }) {
 export default function PatternConfig() {
   const [strictness, setStrictness] = useSearchField('strictness')
   const [selector, setSelector] = usePatternConfig('selector')
+  const [allowEmptyReplace, setAllowEmptyReplace] =
+    useBoolean('allowEmptyReplace')
+
   const onStrictnessChange = useCallback(
     // biome-ignore lint/suspicious/noExplicitAny: onChange event has wrong type signature.
     (e: any) => {
@@ -37,6 +45,21 @@ export default function PatternConfig() {
     },
     [setStrictness],
   )
+
+  const onAllowEmptyReplaceChange = useCallback(
+    (e: any) => {
+      const select = e.target as HTMLElement
+
+      setAllowEmptyReplace(
+        // this condition is inverted on purpose
+        // we only see the class right before it changes,
+        // so take what the value will be, not what it is now.
+        !select.classList.contains('checked') ? 'true' : 'false',
+      )
+    },
+    [setAllowEmptyReplace],
+  )
+
   return (
     <div>
       <h4 style={titleStyle}>
@@ -66,6 +89,12 @@ export default function PatternConfig() {
         onKeyEnterUp={NOOP}
       />
       <h4 style={titleStyle}>Strictness/Selector requires latest ast-grep.</h4>
+      <VSCodeCheckbox
+        value={allowEmptyReplace}
+        onChange={onAllowEmptyReplaceChange}
+      >
+        Make empty replace delete matches
+      </VSCodeCheckbox>
     </div>
   )
 }

--- a/src/webview/SearchSidebar/SearchWidgetContainer/SearchWidget.tsx
+++ b/src/webview/SearchSidebar/SearchWidgetContainer/SearchWidget.tsx
@@ -51,7 +51,9 @@ function ReplaceBar() {
   const [rewrite, setRewrite] = useSearchField('rewrite')
   const { searching, groupedByFileSearchResult } = useSearchResult()
   const disabled =
-    !rewrite || searching || groupedByFileSearchResult.length === 0
+    !(typeof rewrite === 'string') ||
+    searching ||
+    groupedByFileSearchResult.length === 0
   // sadly unport does not support unsub
   useEffectOnce(() => {
     childPort.onMessage('clearSearchResults', () => {

--- a/src/webview/hooks/useSearch.tsx
+++ b/src/webview/hooks/useSearch.tsx
@@ -163,7 +163,7 @@ function getSnapshot() {
  * Either open a file or preview the diff
  */
 export function openAction(payload: OpenPayload) {
-  if (!queryInFlight.rewrite) {
+  if (!(typeof queryInFlight.rewrite === 'string')) {
     openFile(payload)
     return
   }

--- a/src/webview/hooks/useSearch.tsx
+++ b/src/webview/hooks/useSearch.tsx
@@ -26,6 +26,7 @@ let queryInFlight: SearchQuery = {
   strictness: 'smart',
   selector: '',
   lang: '',
+  allowEmptyReplace: false,
 }
 let searching = true
 let searchError: Error | null = null
@@ -163,7 +164,7 @@ function getSnapshot() {
  * Either open a file or preview the diff
  */
 export function openAction(payload: OpenPayload) {
-  if (!(typeof queryInFlight.rewrite === 'string')) {
+  if (queryInFlight.rewrite.length > 0 || !queryInFlight.allowEmptyReplace) {
     openFile(payload)
     return
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `allowEmptyReplace` toggle to delete matches with empty replacements, updating search logic and UI components.
> 
>   - **Behavior**:
>     - Add `allowEmptyReplace` boolean to `SearchQuery` in `types.ts`.
>     - Update `onReplaceAll` and `onCommitChange` in `preview.ts` to handle `allowEmptyReplace`.
>     - Modify `buildCommand` in `search.ts` to pass `--rewrite=""` if `allowEmptyReplace` is true.
>   - **UI Components**:
>     - Add `VSCodeCheckbox` for `allowEmptyReplace` in `PatternConfig.tsx`.
>     - Update `MatchActions`, `CodeBlock`, and `TreeHeader` to check `typeof replacement === 'string'`.
>   - **Hooks**:
>     - Add `useBoolean` hook for `allowEmptyReplace` in `useQuery.tsx`.
>     - Update `useSearchField` and `useSearchOption` to handle `allowEmptyReplace`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ast-grep%2Fast-grep-vscode&utm_source=github&utm_medium=referral)<sup> for 384eb9043b1e4c38fda5063ce2cdae998035a5a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to allow empty replacements in search operations with a new toggle in the configuration panel.
  
- **Bug Fixes**
  - Refined conditions to ensure replacement actions trigger only for valid string inputs, reducing unexpected behaviors.

- **Improvements**
  - Enhanced command handling and search query logic for more consistent and reliable replacement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->