### PR TITLE
fix: detectDefaultBinary check `.exe` first

### DIFF
--- a/src/extension/common.ts
+++ b/src/extension/common.ts
@@ -21,7 +21,9 @@ export async function detectDefaultBinaryAtStart() {
   // https://zenn.dev/hd_nvim/articles/e49ef2c812ae8d#comment-0b861171ac40cb
   // https://github.com/ast-grep/ast-grep-vscode/issues/235
   // https://github.com/nodejs/node/issues/29532#issue-492569087
-  for (const cmd of ['ast-grep', 'ast-grep.exe', 'ast-grep.cmd']) {
+  // `ast-grep.exe` should check first,
+  // otherwise, it will be resolved to `ast-grep` in shell mode
+  for (const cmd of ['ast-grep.exe', 'ast-grep.cmd', 'ast-grep']) {
     if (await testBinaryExist(cmd)) {
       defaultBinary = cmd
       return
@@ -45,13 +47,13 @@ export function resolveBinary() {
 // see https://github.com/ast-grep/ast-grep-vscode/pull/448 for more information
 // TL;DR: windows needs shell: true for non-exe command and quotation for command with space
 export function normalizeCommandForWindows(command: string) {
+  const isExe = command.toLowerCase().endsWith('.exe')
   // windows user may input space in command
   const normalizedCommand =
-    /\s/.test(command) && !command.endsWith('.exe') ? `"${command}"` : command
+    /\s/.test(command) && !isExe ? `"${command}"` : command
   return {
     normalizedCommand,
-    shell:
-      process.platform === 'win32' && !command.toLowerCase().endsWith('.exe'),
+    shell: process.platform === 'win32' && !isExe,
   }
 }
 


### PR DESCRIPTION
https://github.com/ast-grep/ast-grep-vscode/issues/476
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prioritize `.exe` in `detectDefaultBinaryAtStart` and refactor `normalizeCommandForWindows` for better binary resolution on Windows.
> 
>   - **Behavior**:
>     - In `detectDefaultBinaryAtStart`, prioritize checking `ast-grep.exe` before `ast-grep` and `ast-grep.cmd` to ensure correct binary resolution on Windows.
>   - **Functions**:
>     - Refactor `normalizeCommandForWindows` to use `isExe` variable for clarity and consistency.
>   - **Misc**:
>     - Addresses issue https://github.com/ast-grep/ast-grep-vscode/issues/476.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ast-grep%2Fast-grep-vscode&utm_source=github&utm_medium=referral)<sup> for affd79e0a5d8e257c8a7d2857569c71c2417998b. You can [customize](https://app.ellipsis.dev/ast-grep/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection and handling of Windows command variants to ensure smoother execution and avoid shell resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->